### PR TITLE
Using Pure virtual function

### DIFF
--- a/bitcode/RegistryUtil.cpp
+++ b/bitcode/RegistryUtil.cpp
@@ -54,7 +54,7 @@ RUOpenKey(
     DWORD ret = RegOpenKeyExW(RootKey, SubKey, 0, sam, &hSubKey);
     if (ERROR_SUCCESS != ret)
     {
-        log_err "RegOpenKeyExW(%ws) failed, ret = %u", SubKey, ret log_end        
+        //log_err "RegOpenKeyExW(%ws) failed, ret = %u", SubKey, ret log_end        
         return NULL;
     }
 
@@ -115,7 +115,7 @@ RUCreateKey(
     ret = RegCreateKeyExW(RootKey, SubKey, 0, NULL, 0, sam, NULL, &sub_key_handle, &disposition);
     if (ERROR_SUCCESS != ret)
     {
-        log_err "RegCreateKeyExW(%ws) failed, ret = %u", SubKey, ret log_end        
+        //log_err "RegCreateKeyExW(%ws) failed, ret = %u", SubKey, ret log_end        
         return NULL;
     }
     else

--- a/bitcode/bitcode.conf
+++ b/bitcode/bitcode.conf
@@ -1,30 +1,134 @@
 {
-    "file_name": [
-        "C:\\Program Files (x86)\\Parallels\\Parallels Tools\\Services\\prl_tools_service.exe",
-        "C:\\Program Files (x86)\\Parallels\\Parallels Tools\\Services",
-        "C:\\Program Files\\vmware\\vmwaretools"
-    ],
-    "reg_key": [
-        {
-            "root_key": "HKLM",
-            "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\0000",
-            "val_name": "driverdesc",
-            "val_data": "ffffuck"
-        },
-        {
-            "root_key": "HKLM",
-            "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\0000",
-            "val_name": "driverdesc",
-            "val_data": "Parallels"
-        }
-    ],
-    "svc_name": [
-        "vmvss",
-        "Parallels Tools Service"
-    ],
-    "process_name": [
-        "prl_cc.exe"
-
-    ]
+  "file_name": [
+    "C:\\Program Files (x86)\\Parallels\\Parallels Tools\\Services\\prl_tools_service.exe",
+    "C:\\Program Files (x86)\\Parallels\\Parallels Tools\\Services",
+    "C:\\Program Files\\vmware\\vmwaretools",
+    "C:\\Program Files (x86)"
+  ],
+  "reg_key": [
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{0475BB51-5A02-4EE0-B36C-29040FAD2650}",
+      "val_name": "Class",
+      "val_data": "vm3dmp"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\0000",
+      "val_name": "ProviderName",
+      "val_data": "VMware, Inc."
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\0000",
+      "val_name": "DriverDesc",
+      "val_data": "VMware SVGA 3D"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E968-E325-11CE-BFC1-08002BE10318}\\0000\\Settings",
+      "val_name": "Device Description",
+      "val_data": "VMware SVGA 3D"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E96F-E325-11CE-BFC1-08002BE10318}\\0000",
+      "val_name": "ProviderName",
+      "val_data": "VMware, Inc."
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E96F-E325-11CE-BFC1-08002BE10318}\\0000",
+      "val_name": "DriverDesc",
+      "val_data": "VMware Pointing Device"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E96F-E325-11CE-BFC1-08002BE10318}\\0001",
+      "val_name": "ProviderName",
+      "val_data": "VMware, Inc."
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E96F-E325-11CE-BFC1-08002BE10318}\\0001",
+      "val_name": "DriverDesc",
+      "val_data": "VMware USB Pointing Device"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E96F-E325-11CE-BFC1-08002BE10318}\\0002",
+      "val_name": "ProviderName",
+      "val_data": "VMware, Inc."
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E96F-E325-11CE-BFC1-08002BE10318}\\0002",
+      "val_name": "DriverDesc",
+      "val_data": "VMware USB Pointing Device"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E97D-E325-11CE-BFC1-08002BE10318}\\0132",
+      "val_name": "ProviderName",
+      "val_data": "VMware, Inc."
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E97D-E325-11CE-BFC1-08002BE10318}\\0132",
+      "val_name": "DriverDesc",
+      "val_data": "VMware VMCI Bus Device"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E97D-E325-11CE-BFC1-08002BE10318}\\0133",
+      "val_name": "ProviderName",
+      "val_data": "VMware, Inc."
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4D36E97D-E325-11CE-BFC1-08002BE10318}\\0133",
+      "val_name": "DriverDesc",
+      "val_data": "VMware VMCI Host Device"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{6FAE73B7-B735-4B50-A0DA-0DC2484B1F1A}",
+      "val_name": "Class",
+      "val_data": "vm3dmp"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{6FAE73B7-B735-4B50-A0DA-0DC2484B1F1A}",
+      "val_name": "SystemManufacturer",
+      "val_data": "VMware, Inc."
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{6FAE73B7-B735-4B50-A0DA-0DC2484B1F1A}",
+      "val_name": "SystemProductName",
+      "val_data": "VMware Virtual Platform"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 2\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0",
+      "val_name": "Identifier",
+      "val_data": "VMware, VMware Virtual S1.0"
+    },
+    {
+      "root_key": "HKLM",
+      "key_name": "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\0000",
+      "val_name": "DriverDesc",
+      "val_data": "Intel(R) HD Graphics Family"
+    }
+  ],
+  "svc_name": [
+    "vmvss",
+    "Parallels Tools Service",
+    "ALG"
+  ],
+  "process_name": [
+    "prl_cc.exe",
+    "ns.exe"
+  ]
 
 }

--- a/bitcode/bitcode.cpp
+++ b/bitcode/bitcode.cpp
@@ -18,64 +18,56 @@
 /// @brief entry point
 int main()
 {
-    set_log_format(false, false, true);
+    set_log_format(false, false, false);
 
     BCConf _conf;
-    _conf.load_config(L"z:\\work.bob\\bob4-3-antivm\\bitbox\\bitcode\\bitcode.conf");
+    _conf.load_config(L"..\\bitcode\\bitcode.conf");
 
-    BCReg _reg_engine;
-    BCFile _file_engine;
-    BCSvc _svc_engine;
-    BCProcs _proc_engine;
-    
-    if (true != _svc_engine.initialize())
-    {
-        log_err "BCSvc::initialize() failed." log_end;
-        return -1;
-    }
+	std::list<IPBCConf> _iconf;
+	_iconf.push_back(new BCFile);
+	_iconf.push_back(new BCSvc);
+	_iconf.push_back(new BCProcs);
+	_iconf.push_back(new BCReg);
 
-    if (true != _proc_engine.initialize())
-    {
-        log_err "BCProc::initialize() failed." log_end;
-        return -1;
-    }
+	for (auto engine : _iconf)
+	{
+		if (true != engine->initialize())
+		{
+			log_err "initialize() failed." log_end;
+			return -1;
+		}
 
-    // check registries
-    for (auto reg_info : _conf._regs)
-    {
-        if (true == _reg_engine.is_exists(reg_info))
-        {
-            log_info "[found]" log_end;
-            reg_info.dump();
-        }
-    }
-
-    // file check
-    for (auto file_info : _conf._file_names)
-    {
-        if (true == _file_engine.is_file_exists(file_info.c_str()))
-        {
-            log_info "[found] file = %s", file_info.c_str() log_end;
-        }
-    }
-
-    // service check
-    for (auto svc_name : _conf._svc_names)
-    {
-        if (true == _svc_engine.is_svc_exists(svc_name.c_str()))
-        {
-            log_info "[found] service = %s", svc_name.c_str() log_end;
-        }
-    }
-
-    // process check
-    for (auto proc_name : _conf._proc_names)
-    {
-        if (true == _proc_engine.is_process_exists(proc_name.c_str()))
-        {
-            log_info "[found] process = %s is running", proc_name.c_str() log_end;
-        }
-    }
+		BCEngines engine_num = engine->get_engine_value();
+		if (engine_num == REG_ENGINE)
+		{
+			for (auto reg_info : _conf._regs)
+			{
+			    if (true == engine->is_exists(
+					reg_info._key_name.c_str(),
+					reg_info._val_name.c_str(),
+					reg_info._val_data.c_str()))
+			    {
+			        reg_info.dump();
+			    }
+			}
+		}
+		else
+		{
+			std::map<BCEngines, std::list<std::string>>::iterator it = _conf._conf_value.find(engine_num);
+			if (it == _conf._conf_value.end())
+			{
+				log_err "not found map." log_end;
+				return -1;
+			}
+			for (auto names : it->second)
+			{
+			    if (true == engine->is_exists(names.c_str()))
+			    {
+			        log_info "[Detected] = %s", names.c_str() log_end;
+			    }
+			}
+		}
+	}
 
     log_info "press any key to terminate..." log_end;
     _pause;

--- a/bitcode/conf.cpp
+++ b/bitcode/conf.cpp
@@ -16,7 +16,11 @@
 bool BCConf::load_config(const wchar_t * config_path)
 {
     _ASSERTE(NULL != config_path);
-    if (NULL == config_path) return false;
+	if (NULL == config_path)
+	{
+		log_err "not found file : %ws", config_path log_end;
+		return false;
+	}
 
     std::ifstream js;
     js.open(config_path, std::ifstream::in);
@@ -63,20 +67,9 @@ bool BCConf::load_config(const wchar_t * config_path)
         _proc_names.push_back(proc_name.asString());
     }
 
-
-    /*
-    for (auto file_name : _file_names)
-    {
-        log_info "file name = %s", file_name.c_str() log_end;
-    }
-    for (auto svc_name : _svcs)
-    {
-        log_info "svc name = %s", svc_name.c_str() log_end;
-    }
-    for (auto reg : _regs)
-    {
-        reg.dump();
-    }*/
+	_conf_value[FILE_ENGINE] = _file_names;
+	_conf_value[SVC_ENGINE] = _svc_names;
+	_conf_value[PROC_ENGINE] = _proc_names;
 
     return true;
 }

--- a/bitcode/conf.h
+++ b/bitcode/conf.h
@@ -11,6 +11,7 @@
 #include <sal.h>
 #include <string>
 #include <list>
+#include <map>
 #include "log.h"
 
 typedef class RegInfo
@@ -35,7 +36,7 @@ public:
     void dump()
     {
         log_info 
-            "root key = %s, key_name = %s, val_name = %s, val_data = %s", 
+            "[Detected] = Root_Key : %s, Sub_Key : %s, Val_Name : %s, Val_Data : %s", 
             _root_key.c_str(),
             _key_name.c_str(),
             _val_name.c_str(),
@@ -44,14 +45,35 @@ public:
     }
 } *PRegInfo;
 
+typedef enum BCEngines
+{
+	FILE_ENGINE,
+	PROC_ENGINE,
+	SVC_ENGINE,
+	REG_ENGINE
+} *PBCEngines;
+
 typedef class BCConf
 {
 public:
     bool load_config(_In_ const wchar_t* config_path);
 
+	std::list<RegInfo>			_regs;
+	std::map<BCEngines, std::list<std::string>> _conf_value;
+
+private:
     std::list<std::string>      _file_names;
-    std::list<RegInfo>          _regs;
     std::list<std::string>      _svc_names;
     std::list<std::string>      _proc_names;
 
 } *PBCConf;
+
+
+typedef class IBCConf
+{
+public:
+	virtual bool initialize() = 0;
+	virtual void finalize() = 0;
+	virtual BCEngines get_engine_value() = 0;
+	virtual bool is_exists(const char* values, ...) = 0;
+} *IPBCConf;

--- a/bitcode/file_engine.h
+++ b/bitcode/file_engine.h
@@ -8,7 +8,7 @@
 #pragma once
 #include "conf.h"
 
-typedef class BCFile
+typedef class BCFile : public IBCConf
 {
 public:
     BCFile()
@@ -20,11 +20,15 @@ public:
     
     }
 
+	bool initialize() { return true; }
+	void finalize() { return; }
+	BCEngines get_engine_value() { return FILE_ENGINE; }
+
     /// @brief
-    bool is_file_exists(_In_ const char* file_path)
+	bool is_exists(const char* values, ...)
     {
-        _ASSERTE(NULL != file_path);
-        if (NULL == file_path) return false;
+        _ASSERTE(NULL != values);
+        if (NULL == values) return false;
 
         WIN32_FILE_ATTRIBUTE_DATA info = { 0 };
 
@@ -32,7 +36,7 @@ public:
         // CreateFile()이 아닌 GetFileAttributesEx()를 이용하면 파일이 다른 process에 의해 lock되어 있어도
         // 파일 존재여부를 정확히 체크할 수 있다.
         //
-        if (GetFileAttributesExA(file_path, GetFileExInfoStandard, &info) == 0)
+        if (GetFileAttributesExA(values, GetFileExInfoStandard, &info) == 0)
             return false;
         else
             return true;

--- a/bitcode/proc_engine.h
+++ b/bitcode/proc_engine.h
@@ -10,7 +10,7 @@
 #include "util.h"
 #include "process_tree.h"
 
-typedef class BCProcs
+typedef class BCProcs : public IBCConf
 {
 private:
     cprocess_tree   _proc_tree;
@@ -25,7 +25,7 @@ public:
     }
 
     /// @brief
-    bool initialize()
+	bool initialize()
     {
         // build process tree
         if (true != _proc_tree.build_process_tree())
@@ -39,21 +39,25 @@ public:
     }
 
     /// @brief
-    void finalize()
+	void finalize()
     {
         // free process tree
         _proc_tree.clear_process_tree();
     }
 
+	BCEngines get_engine_value() { return PROC_ENGINE; }
+
     /// @brief
-    bool is_process_exists(_In_ const char* proc_name)
+	bool is_exists(const char* values, ...)
     {
-        DWORD pid = _proc_tree.find_process(MbsToWcsEx(proc_name).c_str());
+		_ASSERTE(NULL != values);
+		if (NULL == values) return false;
+
+        DWORD pid = _proc_tree.find_process(MbsToWcsEx(values).c_str());
         if (0 != pid)
         {
             return true;
         }
-
         return false;
     }
 } *PBCProcs;

--- a/bitcode/process_tree.h
+++ b/bitcode/process_tree.h
@@ -65,7 +65,7 @@ typedef bool (*fnproc_tree_callback)(_In_ process& process_info, _In_ DWORD_PTR 
 class cprocess_tree
 {
 public:
-	bool	clear_process_tree() { _proc_map.clear(); }
+	void	clear_process_tree() { _proc_map.clear(); }
 	bool	build_process_tree();
 
 	DWORD			find_process(_In_ const wchar_t* process_name);

--- a/bitcode/reg_engine.h
+++ b/bitcode/reg_engine.h
@@ -1,6 +1,6 @@
 /**
  * @file    reg_engine.h
- * @brief   
+ * @brief
  *
  * @author  Yonhgwhan, Noh (fixbrain@gmail.com)
  * @date    2016.02.28 14:36 created.
@@ -11,34 +11,51 @@
 #include "RegistryUtil.h"
 
 
-typedef class BCReg 
+typedef class BCReg : public IBCConf
 {
+private:
+	std::wstring _key_name;
+	std::wstring _val_name;
+	std::wstring _val_data;
+
 public:
-    BCReg() {}
-    virtual ~BCReg() {}
+	BCReg() {}
+	virtual ~BCReg() {}
 
-    /// @brief  reg_info 를 통해 해당 키/밸류/데이터가 존재하면
-    ///         true 를 리턴한다. 
-    bool is_exists(_In_ RegInfo& reg_info) 
-    {
-        //HKEY key = RUOpenKey(reg_info._root_key.c_str(),
-        //                     reg_info._key_name.c_str(),
-        //                     true);
-        
-        std::wstring data;
-        if (true == RUReadString(HKEY_LOCAL_MACHINE,
-                                 MbsToWcsEx(reg_info._key_name.c_str()).c_str(),
-                                 MbsToWcsEx(reg_info._val_name.c_str()).c_str(), 
-                                 data))
-        {
-            //log_info "%s", data.c_str() log_end;
-            
-            if (std::wstring::npos != data.find(MbsToWcsEx(reg_info._val_data.c_str())))
-            {
-                return true;    // ok, we got!
-            }
-        }
+	bool initialize() { return true; }
+	void finalize() { return; }
+	BCEngines get_engine_value() { return REG_ENGINE; }
 
-        return false;
-    }
+	/// @brief  reg_info 를 통해 해당 키/밸류/데이터가 존재하면
+	///         true 를 리턴한다. 
+	bool is_exists(const char* values, ...)
+	{
+		//HKEY key = RUOpenKey(reg_info._root_key.c_str(),
+		//                     reg_info._key_name.c_str(),
+		//                     true);
+		_ASSERTE(NULL != values);
+		if (NULL == values) return false;
+
+		va_list list;
+		va_start(list, values);
+
+		_key_name = MbsToWcsEx(values);
+		_val_name = MbsToWcsEx(va_arg(list, const char*));
+		_val_data = MbsToWcsEx(va_arg(list, const char*));
+
+		va_end(list);
+
+		std::wstring data;
+		if (true == RUReadString(HKEY_LOCAL_MACHINE, _key_name.c_str(), _val_name.c_str(), data))
+		{
+			//log_info "%s", data.c_str() log_end;
+
+			if (std::wstring::npos != data.find(_val_data.c_str()))
+			{
+				return true;    // ok, we got!
+			}
+		}
+
+		return false;
+	}
 } *PBCReg;

--- a/bitcode/stdafx.h
+++ b/bitcode/stdafx.h
@@ -3,6 +3,7 @@
 #include "targetver.h"
 
 #include <stdio.h>
+#include <stdarg.h>
 #include <tchar.h>
 #include <conio.h>
 

--- a/bitcode/svc_engine.h
+++ b/bitcode/svc_engine.h
@@ -10,7 +10,7 @@
 #include "conf.h"
 
 
-typedef class BCSvc
+typedef class BCSvc : public IBCConf
 {
 private:
     SC_HANDLE _scm_handle;
@@ -39,7 +39,7 @@ public:
     }
 
     /// @brief 
-    void finalize()
+	void finalize()
     {
         if (NULL != _scm_handle)
         {
@@ -47,8 +47,10 @@ public:
         }
     }
 
+	BCEngines get_engine_value() { return SVC_ENGINE; }
+
     /// @brief
-    bool is_svc_exists(_In_ const char* svc_name)
+	bool is_exists(const char* values, ...)
     {
         _ASSERTE(NULL != _scm_handle);
         if (NULL == _scm_handle)
@@ -57,8 +59,8 @@ public:
             return false;
         }
 
-        _ASSERTE(NULL != svc_name);
-        if (NULL == svc_name) return false;
+        _ASSERTE(NULL != values);
+        if (NULL == values) return false;
 
         bool ret = false;
         SC_HANDLE service_handle = NULL;
@@ -66,7 +68,7 @@ public:
         do
         {   
             // already exists?
-            service_handle = OpenServiceA(_scm_handle, svc_name, SERVICE_QUERY_CONFIG);
+            service_handle = OpenServiceA(_scm_handle, values, SERVICE_QUERY_CONFIG);
             if (NULL != service_handle)
             {
                 ret = true; // found


### PR DESCRIPTION
- BCConf::load_config 상대경로 수정
- 레지스트리 엔진은 미구현(너무 어렵네요..)
- 사용법
- enum에 엔진이름으로 된 값을 넣어줌(conf.h).
- 해당 값이 std::liststd::string형을 사용한다면 map에 추가(conf.cpp).
- 모든 엔진 클래스들은 IBCConf클래스를 상속 받음.
- 순수가상함수(총4개)를 정의.
- bitcode.cpp 에서 _iconf에 대해 새로운 엔진 클래스를 push_back
